### PR TITLE
fix: replace biased sort-based shuffle with Fisher-Yates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import { database } from './firebase-config';
 import { ref, get, query, orderByChild } from 'firebase/database';
 import { prompt } from './prompt'
+import { shuffle } from './utils'
 
 import './App.css';
 
@@ -49,7 +50,7 @@ const App: React.FC = () => {
       const snapshot = await get(orderedQuery);
       if (snapshot.exists()) {
         const fetchedData = Object.values(snapshot.val()) as fr0gg[];
-        const shuffledData = fetchedData.sort(() => Math.random() - 0.5);
+        const shuffledData = shuffle(fetchedData);
         // const sortedData = fetchedData.sort((a, b) => {
         //   const dateA = new Date(a.date);
         //   const dateB = new Date(b.date);

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -1,12 +1,9 @@
+import { shuffle } from './utils';
+
 export function prompt(): string {
-    
+
     function sample<T>(arr: T[], n: number): T[] {
-        const result = [...arr];
-        for (let i = result.length - 1; i > 0; i--) {
-            const j = Math.floor(Math.random() * (i + 1));
-            [result[i], result[j]] = [result[j], result[i]]; // Fisher–Yates shuffle
-        }
-        return result.slice(0, n);
+        return shuffle(arr).slice(0, n);
     }
 
     const artistList: string[] = [

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,9 @@
+/** Fisher–Yates shuffle — returns a new shuffled array, does not mutate the original */
+export function shuffle<T>(arr: T[]): T[] {
+  const result = [...arr];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- Replaces the broken `sort(() => Math.random() - 0.5)` shuffle in `App.tsx`
  with a statistically correct Fisher-Yates shuffle
- Extracts the algorithm (previously duplicated inside `prompt.ts`) into a
  new shared `src/utils.ts` utility
- Both `App.tsx` and `prompt.ts` now use a single source of truth

## Why the old approach was wrong
Array.sort requires a consistent, transitive comparator. Returning a random
value each call violates that contract — V8's TimSort exploits transitivity
assumptions, producing a biased distribution where some permutations are far
more likely than others. Fisher-Yates guarantees every permutation has an
equal 1/n! probability.

## Test plan
- [ ] Gallery loads with images in randomized order on each refresh
- [ ] No TypeScript errors (tsc --noEmit)
- [ ] prompt() still returns valid Midjourney prompts with correctly sampled values