### PR TITLE
fix: remove unused imports (useRef, prompt) from App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState } from 'react';
 import { database } from './firebase-config';
 import { ref, get, query, orderByChild } from 'firebase/database';
-import { prompt } from './prompt'
 import { shuffle } from './utils'
 
 import './App.css';


### PR DESCRIPTION
Removes two unused imports that were causing ESLint warnings and breaking the Vercel build.